### PR TITLE
DynamicCluster: chunk init test passed. partitioner online. implemented mirroring and sharding initialization logic.

### DIFF
--- a/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Consensus/ITaskQueue.cs
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Consensus/ITaskQueue.cs
@@ -66,9 +66,12 @@ namespace Trinity.DynamicCluster.Consensus
         /// Post a new task to a partition. The behavior
         /// is undefined when executed on a task queue slave.
         /// </summary>
-        /// <param name="task"></param>
-        /// <param name="partitionId"></param>
-        /// <returns></returns>
-        Task PostTask(ITask task, int partitionId);
+        /// <param name="task">The task to be posted.</param>
+        Task PostTask(ITask task);
+        /// <summary>
+        /// Waits until tasks of the given tag to be all completed.
+        /// </summary>
+        /// <param name="tag">The tag to be waited. See <see cref="ITask.Tag"/>.</param>
+        Task Wait(Guid tag);
     }
 }

--- a/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/DynamicMemoryCloud/ReplicaInformation.cs
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/DynamicMemoryCloud/ReplicaInformation.cs
@@ -11,6 +11,7 @@ namespace Trinity.DynamicCluster.Storage
     /// (i.e. a TrinityServer, or its derivative). A partition contains one or more replicas to guarantee
     /// availability.
     /// </summary>
+    [Serializable]
     public class ReplicaInformation : IEquatable<ReplicaInformation>
     {
         public ReplicaInformation(string addr, int port, Guid id, int partitionId)

--- a/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Storage/ReplicationMode.cs
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Storage/ReplicationMode.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace Trinity.DynamicCluster.Storage
 {
+    [Serializable]
     public enum ReplicationMode
     {
         /// <summary>

--- a/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Tasks/ChunkInitTask.cs
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Tasks/ChunkInitTask.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Trinity.Diagnostics;
+using Trinity.DynamicCluster.Consensus;
+using Trinity.DynamicCluster.Storage;
+using Trinity.Storage;
+
+namespace Trinity.DynamicCluster.Tasks
+{
+    [Serializable]
+    internal class ChunkInitTask : ITask
+    {
+        public static readonly Guid Guid = new Guid("143A2C01-939C-4A2B-92A6-3A26F9FCD38C");
+        private Guid m_guid = Guid.NewGuid();
+        private ReplicationMode m_repmode;
+        private List<ReplicaInformation> m_replicas;
+        [NonSerialized]
+        private IChunkTable m_ctable;
+        [NonSerialized]
+        private CancellationToken m_cancel;
+        [NonSerialized]
+        private DynamicMemoryCloud m_dmc;
+
+        public ChunkInitTask(ReplicationMode replicationMode, IEnumerable<ReplicaInformation> replicas)
+        {
+            m_repmode  = replicationMode;
+            m_replicas = replicas.ToList();
+        }
+
+        public Guid Id => m_guid;
+
+        public Guid Tag => Guid;
+
+        public Task Execute(CancellationToken cancel)
+        {
+            Log.WriteLine($"ChunkInitTask: Initializing with mode {m_repmode}");
+            m_dmc = DynamicMemoryCloud.Instance;
+            m_ctable = DynamicMemoryCloud.Instance.m_chunktable;
+            m_cancel = cancel;
+            switch (m_repmode)
+            {
+                case ReplicationMode.Mirroring:
+                return mirror_init();
+                case ReplicationMode.Sharding:
+                return sharding_init();
+                case ReplicationMode.MirroredSharding:
+                return mirrorshard_init();
+                case ReplicationMode.DistributedHashTable:
+                return dht_init();
+                default:
+                throw new ArgumentException("Invalid replication mode");
+            }
+        }
+
+        private async Task mirror_init()
+        {
+            var frc = new Chunk[]{ Chunk.FullRangeChunk };
+            var tasks = m_replicas.Select(r => m_ctable.SetChunks(r.Id, frc)).ToArray();
+            await Task.WhenAll(tasks);
+        }
+
+        private async Task sharding_init()
+        {
+            List<Chunk> chunks = new List<Chunk>();
+            long step = (long)(ulong.MaxValue / (ulong)m_replicas.Count);
+            long head = long.MinValue;
+            for(int i = 1; i<=m_replicas.Count; ++i)
+            {
+                long tail = head + step;
+                if (i == m_replicas.Count) tail = long.MaxValue;
+                chunks.Add(new Chunk(head, tail));
+                head = tail + 1;
+            }
+            var tasks = m_replicas.Select(r => m_ctable.SetChunks(r.Id, chunks)).ToArray();
+            await Task.WhenAll(tasks);
+        }
+
+        private async Task mirrorshard_init()
+        {
+            throw new NotImplementedException();
+        }
+
+        private async Task dht_init()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Tasks/ITask.cs
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Tasks/ITask.cs
@@ -12,7 +12,20 @@ namespace Trinity.DynamicCluster.Tasks
     /// </summary>
     public interface ITask
     {
+        /// <summary>
+        /// The Id of this task.
+        /// </summary>
         Guid Id { get; }
+        /// <summary>
+        /// The tag of this task, indicating the task group.
+        /// An implementation should generate a constant for
+        /// all instances of this type.
+        /// </summary>
+        Guid Tag { get; }
+        /// <summary>
+        /// Execute the task asynchronously.
+        /// </summary>
+        /// <param name="cancel">The task should be cancelled if the cancellation token is fired.</param>
         Task Execute(CancellationToken cancel);
     }
 }

--- a/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Tasks/PersistencyTask.cs
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Tasks/PersistencyTask.cs
@@ -1,21 +1,24 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Trinity.DynamicCluster.Tasks
 {
     [Serializable]
-    public class NopTask : ITask
+    internal class PersistencyTask : ITask
     {
-        public static readonly Guid Guid  = new Guid("509B35C6-A6FD-4A33-A034-26BADB4D0D06");
+        public static readonly Guid Guid = new Guid("01818198-FF59-4292-B734-F8243D133B72");
         private Guid m_guid = Guid.NewGuid();
+
         public Guid Id => m_guid;
 
         public Guid Tag => Guid;
 
         public async Task Execute(CancellationToken cancel)
         {
-            await Task.Delay(1000, cancel);
         }
     }
 }

--- a/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Tasks/ReplicatorTask.cs
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Tasks/ReplicatorTask.cs
@@ -5,17 +5,17 @@ using System.Threading.Tasks;
 namespace Trinity.DynamicCluster.Tasks
 {
     [Serializable]
-    public class NopTask : ITask
+    internal class ReplicatorTask: ITask
     {
-        public static readonly Guid Guid  = new Guid("509B35C6-A6FD-4A33-A034-26BADB4D0D06");
+        public static readonly Guid Guid = new Guid("0ADA7058-AAD6-4383-95C3-3022E4DBBD50");
         private Guid m_guid = Guid.NewGuid();
+
         public Guid Id => m_guid;
 
         public Guid Tag => Guid;
 
         public async Task Execute(CancellationToken cancel)
         {
-            await Task.Delay(1000, cancel);
         }
     }
 }

--- a/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Trinity.DynamicCluster.csproj
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Trinity.DynamicCluster.csproj
@@ -42,6 +42,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
@@ -75,9 +76,12 @@
     <Compile Include="Storage\Partitioner.cs" />
     <Compile Include="Health\HealthStatus.cs" />
     <Compile Include="Storage\ReplicationMode.cs" />
+    <Compile Include="Tasks\ChunkInitTask.cs" />
     <Compile Include="Tasks\Executor.cs" />
     <Compile Include="Tasks\ITask.cs" />
     <Compile Include="Tasks\NopTask.cs" />
+    <Compile Include="Tasks\PersistencyTask.cs" />
+    <Compile Include="Tasks\ReplicatorTask.cs" />
     <Compile Include="Utils.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Utils.cs
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.DynamicCluster/Utils.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Net.NetworkInformation;
 using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -133,6 +135,25 @@ namespace Trinity.DynamicCluster
             var n2 = names[r.Next(names.Length)];
 
             return n1 + " " + n2;
+        }
+
+        public static T Deserialize<T>(byte[] payload)
+        {
+            IFormatter fmt = new BinaryFormatter();
+            using (var ms = new MemoryStream(payload))
+            {
+                return (T)fmt.Deserialize(ms);
+            }
+        }
+
+        public static byte[] Serialize<T>(T payload)
+        {
+            IFormatter fmt = new BinaryFormatter();
+            using (var ms = new MemoryStream())
+            {
+                fmt.Serialize(ms, payload);
+                return ms.ToArray();
+            }
         }
     }
 }

--- a/src/Modules/Trinity.DynamicCluster/Trinity.ServiceFabric.GarphEngine.Runtime/Interfaces/ServiceFabricHealthManager.cs
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.ServiceFabric.GarphEngine.Runtime/Interfaces/ServiceFabricHealthManager.cs
@@ -15,10 +15,6 @@ namespace Trinity.ServiceFabric.GarphEngine.Infrastructure.Interfaces
         private System.Fabric.FabricClient m_fclient;
         private const string sourceId = "Trinity.ServiceFabric.HealthManager";
 
-        public ServiceFabricHealthManager(string sourceId)
-        {
-        }
-
         private HealthState _hstate(HealthStatus hstatus)
         {
             switch (hstatus)
@@ -32,6 +28,7 @@ namespace Trinity.ServiceFabric.GarphEngine.Infrastructure.Interfaces
 
         public void Dispose()
         {
+            m_fclient.Dispose();
         }
 
         public void Start(CancellationToken cancellationToken)

--- a/src/Modules/Trinity.DynamicCluster/Trinity.ServiceFabric.GarphEngine.Runtime/Interfaces/ServiceFabricUtils.cs
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.ServiceFabric.GarphEngine.Runtime/Interfaces/ServiceFabricUtils.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.ServiceFabric.Data;
+using System;
+using System.Collections.Generic;
+using System.Fabric;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Trinity.Diagnostics;
+using Trinity.DynamicCluster.Consensus;
+
+namespace Trinity.ServiceFabric.GarphEngine.Infrastructure.Interfaces
+{
+    internal static class ServiceFabricUtils
+    {
+        internal static async Task<T> CreateReliableStateAsync<T>(IService svc, string name, int p) where T : IReliableState
+        {
+            name = $"{name}-P{p}";
+            await GraphEngineStatefulServiceRuntime.Instance.GetRoleAsync();
+            var statemgr = GraphEngineStatefulServiceRuntime.Instance.StateManager;
+            T ret = default(T);
+            await DoWithTimeoutRetryImpl(async () =>
+            {
+                if (svc.IsMaster)
+                {
+                    ret = await statemgr.GetOrAddAsync<T>(name);
+                }
+                else
+                {
+                    var result = await statemgr.TryGetAsync<T>(name);
+                    if (result.HasValue) { ret = result.Value; }
+                    else { throw new TimeoutException(); }
+                }
+            });
+            return ret;
+        }
+
+        internal static ITransaction CreateTransaction()
+        {
+            var statemgr = GraphEngineStatefulServiceRuntime.Instance.StateManager;
+            return statemgr.CreateTransaction();
+        }
+
+        private static async Task DoWithTimeoutRetryImpl(Func<Task> task)
+        {
+retry:
+            try { await task(); }
+            catch (TimeoutException)
+            { await Task.Delay(1000); goto retry; }
+            catch (FabricNotReadableException)
+            { Log.WriteLine("Fabric not readable from Primary/ActiveSecondary, retrying."); await Task.Delay(1000); goto retry; }
+            catch (OperationCanceledException ex)
+            { Log.WriteLine(LogLevel.Warning, "{0}", $"ServiceFabricUtils: Operation cancelled, retry aborted: {ex.ToString()}."); throw; }
+            catch (Exception ex)
+            {
+                Log.WriteLine(LogLevel.Warning, "{0}", $"ServiceFabricUtils: {ex.ToString()}.");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Retry stepper
+        /// </summary>
+        internal static async Task DoWithTimeoutRetry(params Func<Task>[] tasks)
+        {
+            foreach (var task in tasks)
+            {
+                await DoWithTimeoutRetryImpl(task);
+            }
+        }
+    }
+}

--- a/src/Modules/Trinity.DynamicCluster/Trinity.ServiceFabric.GarphEngine.Runtime/Trinity.ServiceFabric.GarphEngine.Environment.csproj
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.ServiceFabric.GarphEngine.Runtime/Trinity.ServiceFabric.GarphEngine.Environment.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Interfaces\ReliableTaskQueue.cs" />
     <Compile Include="Interfaces\ServiceFabricChunkTable.cs" />
     <Compile Include="Interfaces\ServiceFabricHealthManager.cs" />
+    <Compile Include="Interfaces\ServiceFabricUtils.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TrinityServerRuntimeManager.cs" />
     <Compile Include="TrinitySeverRuntimeMangerBase.cs" />

--- a/src/Modules/Trinity.DynamicCluster/Trinity.ServiceFabric.GarphEngine.Runtime/TrinityServerRuntimeManager.cs
+++ b/src/Modules/Trinity.DynamicCluster/Trinity.ServiceFabric.GarphEngine.Runtime/TrinityServerRuntimeManager.cs
@@ -4,6 +4,7 @@ using System.Fabric;
 using System.Fabric.Query;
 using System.Linq;
 using Trinity.Diagnostics;
+using Trinity.DynamicCluster.Storage;
 using Trinity.Network;
 using Trinity.Utilities;
 
@@ -66,6 +67,7 @@ namespace Trinity.ServiceFabric.GarphEngine.Infrastructure
         {
             lock (SingletonLockObject)
             {
+                (Global.CloudStorage as DynamicMemoryCloud)?.Close();
                 ServiceFabricTrinityServerInstance?.Stop();
                 ServiceFabricTrinityServerInstance = null;
                 return TrinityErrorCode.E_SUCCESS;

--- a/src/Trinity.Core/Storage/MemoryCloud/Chunk.cs
+++ b/src/Trinity.Core/Storage/MemoryCloud/Chunk.cs
@@ -7,8 +7,9 @@ using System.Threading.Tasks;
 namespace Trinity.Storage
 {
     /// <summary>
-    /// Represents
+    /// Represents a range in the cell Id address space.
     /// </summary>
+    [Serializable]
     public class Chunk : IEquatable<Chunk>
     {
         public Chunk(long lowKey, long highKey)


### PR DESCRIPTION
Another all-nighter..
@TaviTruman , please run tools\build.bat again to rebuild the trinity core after you pull this update.

The cluster can now be started in mirror/shard mode, and for a quick demo I'd recommend mirror mode. still got to work on tsl codegen for the correct semantics of sharding+message passing, but for mirror mode, messages will always be sent to the first available replica.

Also, I've tested that the partition health monitor is ready, and the behavior is consistent with SF infra reports.